### PR TITLE
Fixed issues with writing and reading numbers with commas & Increased precisoon

### DIFF
--- a/autosens/Core.cs
+++ b/autosens/Core.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -88,7 +89,7 @@ namespace autosens
                 oldNumber = m.Groups[2].Value;
 
                 string formattedValue;
-                formattedValue = newValue.ToString("0.0###");
+                formattedValue = newValue.ToString("0.0###", CultureInfo.GetCultureInfo("en-US"));
                 return prefix + formattedValue;
             });
             if(oldNumber == "")
@@ -266,7 +267,7 @@ namespace autosens
             {
                 return "Not Found";
             }
-            return finalCm.ToString("0.0");
+            return finalCm.ToString("0.0#####");
         }
 
         private static float OldSensBinary(string filePath, string searchText)
@@ -319,10 +320,7 @@ namespace autosens
 
             if (match.Success)
             {
-                string numberString = "0.0";
-                
-                if(match.Groups[1].Value.Contains(","))
-                    numberString = match.Groups[1].Value.Replace(",", ".");
+                string numberString = match.Groups[1].Value.Replace(",", ".");
 
                 Console.WriteLine("Found current sensitivity: " + numberString);
                 return float.Parse(numberString);

--- a/autosens/Core.cs
+++ b/autosens/Core.cs
@@ -207,7 +207,7 @@ namespace autosens
                 try
                 {
                     Console.WriteLine("Reading config for " + game.name + " at " + game.configPath);
-                    currentSens = OldSensCfg(game.configPath, game.replacementText);
+                    currentSens = GetCurrentSensCfg(game.configPath, game.replacementText);
                 }
                 catch
                 {
@@ -277,18 +277,22 @@ namespace autosens
             return 0f;
         }
 
-        private static float OldSensCfg(string filePath, string searchText)
+        private static float GetCurrentSensCfg(string filePath, string searchText)
         {
             string content = File.ReadAllText(filePath);
 
-            string pattern = $@"{Regex.Escape(searchText)}.*?(-?[0-9]+(?:\.[0-9]+)?)";
+            string pattern = $@"{Regex.Escape(searchText)}.*?(-?[0-9]+(?:[.,][0-9]+)?)";
 
             Match match = Regex.Match(content, pattern);
 
             if (match.Success)
             {
-                Console.WriteLine("Found old sensitivity: " + match.Groups[1].Value);
-                string numberString = match.Groups[1].Value;
+                string numberString = "0.0";
+                
+                if(match.Groups[1].Value.Contains(","))
+                    numberString = match.Groups[1].Value.Replace(",", ".");
+
+                Console.WriteLine("Found current sensitivity: " + numberString);
                 return float.Parse(numberString);
             }
             return 0;

--- a/autosens/Forms/Form1.Designer.cs
+++ b/autosens/Forms/Form1.Designer.cs
@@ -44,7 +44,7 @@
             this.comboGame.Font = new System.Drawing.Font("Microsoft Sans Serif", 13.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.comboGame.FormattingEnabled = true;
             this.comboGame.Items.AddRange(new object[] { "The Finals", "Battlefield V", "Counterstrike 2" });
-            this.comboGame.Location = new System.Drawing.Point(209, 8);
+            this.comboGame.Location = new System.Drawing.Point(208, 8);
             this.comboGame.Margin = new System.Windows.Forms.Padding(0);
             this.comboGame.Name = "comboGame";
             this.comboGame.Size = new System.Drawing.Size(181, 30);
@@ -76,7 +76,7 @@
             // textBox1
             // 
             this.textBox1.Font = new System.Drawing.Font("Microsoft Sans Serif", 13.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.textBox1.Location = new System.Drawing.Point(209, 54);
+            this.textBox1.Location = new System.Drawing.Point(208, 54);
             this.textBox1.Margin = new System.Windows.Forms.Padding(0);
             this.textBox1.Name = "textBox1";
             this.textBox1.Size = new System.Drawing.Size(181, 28);
@@ -87,7 +87,7 @@
             // button1
             // 
             this.button1.Font = new System.Drawing.Font("Microsoft Sans Serif", 13.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.button1.Location = new System.Drawing.Point(209, 120);
+            this.button1.Location = new System.Drawing.Point(208, 120);
             this.button1.Margin = new System.Windows.Forms.Padding(0);
             this.button1.Name = "button1";
             this.button1.Size = new System.Drawing.Size(180, 35);
@@ -112,7 +112,7 @@
             // 
             this.label3.AutoSize = true;
             this.label3.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label3.Location = new System.Drawing.Point(207, 89);
+            this.label3.Location = new System.Drawing.Point(208, 89);
             this.label3.Margin = new System.Windows.Forms.Padding(0);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(61, 15);
@@ -125,7 +125,7 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.BackColor = System.Drawing.SystemColors.Control;
-            this.ClientSize = new System.Drawing.Size(403, 162);
+            this.ClientSize = new System.Drawing.Size(393, 162);
             this.Controls.Add(this.label3);
             this.Controls.Add(this.button2);
             this.Controls.Add(this.button1);
@@ -141,6 +141,7 @@
             this.Name = "Form1";
             this.Padding = new System.Windows.Forms.Padding(8);
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "Autosens";
             this.Load += new System.EventHandler(this.Form1_Load);
             this.Enter += new System.EventHandler(this.Form1_Enter);
             this.ResumeLayout(false);

--- a/autosens/Forms/Form1.Designer.cs
+++ b/autosens/Forms/Form1.Designer.cs
@@ -43,10 +43,7 @@
             this.comboGame.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboGame.Font = new System.Drawing.Font("Microsoft Sans Serif", 13.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.comboGame.FormattingEnabled = true;
-            this.comboGame.Items.AddRange(new object[] {
-            "The Finals",
-            "Battlefield V",
-            "Counterstrike 2"});
+            this.comboGame.Items.AddRange(new object[] { "The Finals", "Battlefield V", "Counterstrike 2" });
             this.comboGame.Location = new System.Drawing.Point(209, 8);
             this.comboGame.Margin = new System.Windows.Forms.Padding(0);
             this.comboGame.Name = "comboGame";
@@ -58,7 +55,7 @@
             // 
             this.label1.AutoSize = true;
             this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 13.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label1.Location = new System.Drawing.Point(8, 8);
+            this.label1.Location = new System.Drawing.Point(7, 11);
             this.label1.Margin = new System.Windows.Forms.Padding(0);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(61, 24);
@@ -69,7 +66,7 @@
             // 
             this.label2.AutoSize = true;
             this.label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 13.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label2.Location = new System.Drawing.Point(8, 54);
+            this.label2.Location = new System.Drawing.Point(7, 57);
             this.label2.Margin = new System.Windows.Forms.Padding(0);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(71, 24);
@@ -102,7 +99,7 @@
             // button2
             // 
             this.button2.Font = new System.Drawing.Font("Microsoft Sans Serif", 13.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.button2.Location = new System.Drawing.Point(8, 120);
+            this.button2.Location = new System.Drawing.Point(5, 120);
             this.button2.Margin = new System.Windows.Forms.Padding(0);
             this.button2.Name = "button2";
             this.button2.Size = new System.Drawing.Size(180, 35);
@@ -126,9 +123,9 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.AutoSize = true;
             this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.ClientSize = new System.Drawing.Size(403, 168);
+            this.BackColor = System.Drawing.SystemColors.Control;
+            this.ClientSize = new System.Drawing.Size(403, 162);
             this.Controls.Add(this.label3);
             this.Controls.Add(this.button2);
             this.Controls.Add(this.button1);
@@ -138,17 +135,16 @@
             this.Controls.Add(this.comboGame);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.Location = new System.Drawing.Point(15, 15);
             this.Margin = new System.Windows.Forms.Padding(2);
             this.MaximizeBox = false;
             this.Name = "Form1";
             this.Padding = new System.Windows.Forms.Padding(8);
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-            this.Text = "Autosens";
             this.Load += new System.EventHandler(this.Form1_Load);
             this.Enter += new System.EventHandler(this.Form1_Enter);
             this.ResumeLayout(false);
             this.PerformLayout();
-
         }
 
         #endregion

--- a/autosens/Forms/Form3.Designer.cs
+++ b/autosens/Forms/Form3.Designer.cs
@@ -45,7 +45,7 @@
             // 
             this.label1.AutoSize = true;
             this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 13.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label1.Location = new System.Drawing.Point(15, 19);
+            this.label1.Location = new System.Drawing.Point(8, 19);
             this.label1.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(39, 24);
@@ -55,7 +55,7 @@
             // label2
             // 
             this.label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 13.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label2.Location = new System.Drawing.Point(15, 52);
+            this.label2.Location = new System.Drawing.Point(8, 52);
             this.label2.Margin = new System.Windows.Forms.Padding(0);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(44, 24);
@@ -65,7 +65,7 @@
             // label3
             // 
             this.label3.Font = new System.Drawing.Font("Microsoft Sans Serif", 13.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label3.Location = new System.Drawing.Point(15, 91);
+            this.label3.Location = new System.Drawing.Point(8, 91);
             this.label3.Margin = new System.Windows.Forms.Padding(0);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(236, 24);
@@ -75,7 +75,7 @@
             // steamIDHint
             // 
             this.steamIDHint.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.steamIDHint.Location = new System.Drawing.Point(16, 115);
+            this.steamIDHint.Location = new System.Drawing.Point(9, 115);
             this.steamIDHint.Margin = new System.Windows.Forms.Padding(0);
             this.steamIDHint.Name = "steamIDHint";
             this.steamIDHint.Size = new System.Drawing.Size(235, 15);
@@ -88,7 +88,7 @@
             // label5
             // 
             this.label5.Font = new System.Drawing.Font("Microsoft Sans Serif", 13.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label5.Location = new System.Drawing.Point(15, 132);
+            this.label5.Location = new System.Drawing.Point(8, 133);
             this.label5.Margin = new System.Windows.Forms.Padding(0);
             this.label5.Name = "label5";
             this.label5.Size = new System.Drawing.Size(236, 24);
@@ -98,7 +98,7 @@
             // textBox1
             // 
             this.textBox1.Font = new System.Drawing.Font("Microsoft Sans Serif", 13.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.textBox1.Location = new System.Drawing.Point(350, 48);
+            this.textBox1.Location = new System.Drawing.Point(282, 48);
             this.textBox1.Margin = new System.Windows.Forms.Padding(6);
             this.textBox1.Name = "textBox1";
             this.textBox1.Size = new System.Drawing.Size(177, 28);
@@ -107,7 +107,7 @@
             // textBox2
             // 
             this.textBox2.Font = new System.Drawing.Font("Microsoft Sans Serif", 13.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.textBox2.Location = new System.Drawing.Point(350, 89);
+            this.textBox2.Location = new System.Drawing.Point(282, 89);
             this.textBox2.Margin = new System.Windows.Forms.Padding(6);
             this.textBox2.Name = "textBox2";
             this.textBox2.Size = new System.Drawing.Size(177, 28);
@@ -116,7 +116,7 @@
             // textBox3
             // 
             this.textBox3.Font = new System.Drawing.Font("Microsoft Sans Serif", 13.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.textBox3.Location = new System.Drawing.Point(350, 129);
+            this.textBox3.Location = new System.Drawing.Point(282, 129);
             this.textBox3.Margin = new System.Windows.Forms.Padding(6);
             this.textBox3.Name = "textBox3";
             this.textBox3.Size = new System.Drawing.Size(177, 28);
@@ -125,7 +125,7 @@
             // button1
             // 
             this.button1.Font = new System.Drawing.Font("Microsoft Sans Serif", 13.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.button1.Location = new System.Drawing.Point(424, 185);
+            this.button1.Location = new System.Drawing.Point(357, 194);
             this.button1.Margin = new System.Windows.Forms.Padding(2);
             this.button1.Name = "button1";
             this.button1.Size = new System.Drawing.Size(102, 32);
@@ -137,7 +137,7 @@
             // button2
             // 
             this.button2.Font = new System.Drawing.Font("Microsoft Sans Serif", 13.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.button2.Location = new System.Drawing.Point(19, 185);
+            this.button2.Location = new System.Drawing.Point(8, 193);
             this.button2.Margin = new System.Windows.Forms.Padding(2);
             this.button2.Name = "button2";
             this.button2.Size = new System.Drawing.Size(172, 32);
@@ -152,7 +152,7 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
             this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.ClientSize = new System.Drawing.Size(537, 234);
+            this.ClientSize = new System.Drawing.Size(465, 234);
             this.Controls.Add(this.button2);
             this.Controls.Add(this.button1);
             this.Controls.Add(this.textBox3);
@@ -175,7 +175,6 @@
             this.Load += new System.EventHandler(this.Form3_Load);
             this.ResumeLayout(false);
             this.PerformLayout();
-
         }
 
         #endregion

--- a/autosens/Storage.cs
+++ b/autosens/Storage.cs
@@ -140,7 +140,8 @@ namespace autosens
                     new Game { name = "The Finals", conversionCalc = "571.5 / [cm]", reverseCalc = "571.5 / [sens]", configPathTemplate = "[LOCALAPPDATA]\\Discovery\\Saved\\SaveGames\\EmbarkOptionSaveGame.sav", replacementText = "MouseSensitivity", configPath = " ", currentSensitivity = "0.0"},
                     new Game { name = "Counter-Strike 2", conversionCalc = "25.977 / [cm]", reverseCalc = "25.977 / [sens]", configPathTemplate = "[STEAM]\\userdata\\[STEAMID]\\730\\local\\cfg\\cs2_user_convars_0_slot0.vcfg", replacementText = "\"sensitivity\"", configPath = " ", currentSensitivity = "0.0"},
                     new Game { name = "Battlefield V", conversionCalc = "((166.24 / [cm]) - 3.3333) * 0.0015", reverseCalc = "166.24 / (([sens] / 0.0015) + 3.333)", configPathTemplate = "[DOCUMENTS]\\Battlefield V\\settings\\PROFSAVE_profile_synced", replacementText = "GstInput.MouseSensitivity ", configPath = " ", currentSensitivity = "0.0"},
-                    new Game { name = "Deadlock", conversionCalc = "12.9886 / [cm]", reverseCalc = "12.9886 / [sens]", configPathTemplate = "[STEAM]\\steamapps\\common\\Deadlock\\game\\citadel\\cfg\\user_convars_0_slot0.vcfg", replacementText = "\"sensitvity\"", configPath = " ", currentSensitivity = "0.0"}, new Game { name = "Battlefield 6", conversionCalc = "((329.16 / [cm]) - 1.3333)", reverseCalc = "329.16 / ([sens] + 1.333)", configPathTemplate = "[DOCUMENTS]\\Battlefield 6\\settings\\steam\\PROFSAVE_profile", replacementText = "GstInput.MouseSensitivity ", configPath = " ", currentSensitivity = "0.0"},
+                    new Game { name = "Deadlock", conversionCalc = "12.9886 / [cm]", reverseCalc = "12.9886 / [sens]", configPathTemplate = "[STEAM]\\steamapps\\common\\Deadlock\\game\\citadel\\cfg\\user_convars_0_slot0.vcfg", replacementText = "\"sensitvity\"", configPath = " ", currentSensitivity = "0.0"}, 
+                    new Game { name = "Battlefield 6", conversionCalc = "((329.16 / [cm]) - 1.3333)", reverseCalc = "329.16 / ([sens] + 1.333)", configPathTemplate = "[DOCUMENTS]\\Battlefield 6\\settings\\steam\\PROFSAVE_profile", replacementText = "GstInput.MouseSensitivity ", configPath = " ", currentSensitivity = "0.0"},
                     new Game { name = "Valorant", conversionCalc = "8.164 / [cm]", reverseCalc = "8.164 / [sens]", configPathTemplate = "[LOCALAPPDATA]\\VALORANT\\Saved\\Config\\[UNKNOWN]\\Windows\\RiotUserSettings.ini", replacementText = "MouseSensitivity=", configPath = " ", currentSensitivity = "0.0"},
                     new Game { name = "Overwatch 2", conversionCalc = "86.591 / [cm]", reverseCalc = "86.591 / [sens]", configPathTemplate = "Overwatch's sensitivity isn't stored locally, this is just here so you can use this tool to convert your sensitivity manually", replacementText = "hi :3", configPath = " ", currentSensitivity = "0.0"},
                     new Game { name = "ARC Raiders X Axis", conversionCalc = "419.9195 / [cm]", reverseCalc = "419.9195 / [sens]", configPathTemplate = "[LOCALAPPDATA]\\PioneerGame\\Saved\\SaveGames\\EmbarkOptionSaveGame.sav", replacementText = "SensitivityXAxis", configPath = " ", currentSensitivity = "0.0"},
@@ -179,18 +180,18 @@ namespace autosens
         private static string GetSteamPath()
         {
             string defaultPath = "C:\\Program Files (x86)\\Steam";
-            string steamPath = Registry.GetValue("HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Valve\\Steam", "InstallPath", defaultPath) as string;
+            string path = Registry.GetValue("HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Valve\\Steam", "InstallPath", defaultPath) as string;
 
             //32 Bit
-            if (string.IsNullOrEmpty(steamPath))
+            if (string.IsNullOrEmpty(path))
             {
-                steamPath = Registry.GetValue(
+                path = Registry.GetValue(
                     "HKEY_LOCAL_MACHINE\\SOFTWARE\\Valve\\Steam",
                     "InstallPath",
                     defaultPath) as string;
             }
 
-            return steamPath;
+            return path;
         }
     }
 }

--- a/autosens/autosens.csproj
+++ b/autosens/autosens.csproj
@@ -14,6 +14,7 @@
     <Deterministic>true</Deterministic>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -24,10 +25,10 @@
     <UpdatePeriodically>false</UpdatePeriodically>
     <UpdateRequired>false</UpdateRequired>
     <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationRevision>1</ApplicationRevision>
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
+    <PublishWizardCompleted>true</PublishWizardCompleted>
     <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -52,8 +53,21 @@
   <PropertyGroup>
     <StartupObject />
   </PropertyGroup>
+  <PropertyGroup>
+    <ManifestCertificateThumbprint>04E8072C728E87EA625F9DA5ACEC24536099A5B7</ManifestCertificateThumbprint>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ManifestKeyFile>autosens_TemporaryKey.pfx</ManifestKeyFile>
+  </PropertyGroup>
+  <PropertyGroup>
+    <GenerateManifests>true</GenerateManifests>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SignManifests>true</SignManifests>
+  </PropertyGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="autosens_TemporaryKey.pfx" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Fixes
Fixed issues with reading and writing floats with commas. Example: "1.5" instead of "1,5"

## Changes
Changed the precision of GetCurrentCM method. `return finalCm.ToString("0.0#####");` 
`Current: ` often showed 0.0 instead of small numbers

## Minor UI Alignment 
